### PR TITLE
feat: add capability to stop allocations to job-runner policy

### DIFF
--- a/job-runner.policy.hcl
+++ b/job-runner.policy.hcl
@@ -1,7 +1,7 @@
 # See https://developer.hashicorp.com/nomad/tutorials/access-control/access-control-policies for ACL Policy details
 
 namespace "default" {
-  capabilities = ["list-jobs", "read-job", "submit-job"]
+  capabilities = ["list-jobs", "read-job", "submit-job", "alloc-lifecycle"]
 }
 
 node {

--- a/main.go
+++ b/main.go
@@ -262,7 +262,7 @@ func main() {
 			Environment: pulumi.StringMap{
 				"LC_ACL_TOKEN": aclTokenSecret,
 			},
-			Create: pulumi.String("nomad acl policy apply -address=https://localhost:4646 -ca-cert=/etc/nomad.d/nomad-agent-ca.pem -token=\"$LC_ACL_TOKEN\" -description=\"For running jobs and reading Node status in CI workflows\" job-runner /etc/nomad.d/job-runner.policy.hcl"),
+			Create: pulumi.String("nomad acl policy apply -address=https://localhost:4646 -ca-cert=/etc/nomad.d/nomad-agent-ca.pem -token=\"$LC_ACL_TOKEN\" -description=\"For running jobs, reading Node status, and cancelling allocations in CI workflows\" job-runner /etc/nomad.d/job-runner.policy.hcl"),
 			Triggers: pulumi.Array{
 				copyJobRunnerPolicy.ID(),
 				aclBootstrap.ID(),


### PR DESCRIPTION
Required to allow the GitHub CI to stop/kill running Nomad allocations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job runner can now cancel allocations in CI workflows, extending its permissions for improved workflow control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->