### PR TITLE
Improvements and missing policy

### DIFF
--- a/job-runner.policy.hcl
+++ b/job-runner.policy.hcl
@@ -1,7 +1,7 @@
 # See https://developer.hashicorp.com/nomad/tutorials/access-control/access-control-policies for ACL Policy details
 
 namespace "default" {
-  capabilities = ["list-jobs", "read-job", "submit-job"]
+  capabilities = ["list-jobs", "read-job", "submit-job", "alloc-lifecycle"]
 }
 
 node {

--- a/main.go
+++ b/main.go
@@ -262,7 +262,7 @@ func main() {
 			Environment: pulumi.StringMap{
 				"LC_ACL_TOKEN": aclTokenSecret,
 			},
-			Create: pulumi.String("nomad acl policy apply -address=https://localhost:4646 -ca-cert=/etc/nomad.d/nomad-agent-ca.pem -token=\"$LC_ACL_TOKEN\" -description=\"For running jobs and reading Node status in CI workflows\" job-runner /etc/nomad.d/job-runner.policy.hcl"),
+			Create: pulumi.String("nomad acl policy apply -address=https://localhost:4646 -ca-cert=/etc/nomad.d/nomad-agent-ca.pem -token=\"$LC_ACL_TOKEN\" -description=\"For running jobs, reading Node status, and cancelling allocations in CI workflows\" job-runner /etc/nomad.d/job-runner.policy.hcl"),
 			Triggers: pulumi.Array{
 				copyJobRunnerPolicy.ID(),
 				aclBootstrap.ID(),

--- a/main.go
+++ b/main.go
@@ -274,18 +274,23 @@ func main() {
 		}
 
 		influxDBTokenSecret := cfg.RequireSecret("influxDBToken")
-		unytDurableObjectsURL := cfg.Require("unytDurableObjectsURL")
+		unytDurableObjectsURL := pulumi.String(cfg.Require("unytDurableObjectsURL"))
 		unytDurableObjectsSecret := cfg.RequireSecret("unytDurableObjectsSecret")
 		_, err = remote.NewCommand(ctx, "add-nomad-jobs-vars", &remote.CommandArgs{
 			Connection: conn,
 			Environment: pulumi.StringMap{
 				"LC_ACL_TOKEN":                   aclTokenSecret,
 				"LC_INFLUX_TOKEN":                influxDBTokenSecret,
-				"LC_UNYT_DURABLE_OBJECTS_URL":    pulumi.String(unytDurableObjectsURL),
+				"LC_UNYT_DURABLE_OBJECTS_URL":    unytDurableObjectsURL,
 				"LC_UNYT_DURABLE_OBJECTS_SECRET": unytDurableObjectsSecret,
 			},
-			Create:   pulumi.String("nomad var put -address=https://localhost:4646 -ca-cert=/etc/nomad.d/nomad-agent-ca.pem -token=\"$LC_ACL_TOKEN\" nomad/jobs INFLUX_TOKEN=\"$LC_INFLUX_TOKEN\" UNYT_DURABLE_OBJECTS_URL=\"$LC_UNYT_DURABLE_OBJECTS_URL\" UNYT_DURABLE_OBJECTS_SECRET=\"$LC_UNYT_DURABLE_OBJECTS_SECRET\""),
-			Triggers: pulumi.Array{influxDBTokenSecret, droplet.ID()},
+			Create: pulumi.String("nomad var put -address=https://localhost:4646 -ca-cert=/etc/nomad.d/nomad-agent-ca.pem -token=\"$LC_ACL_TOKEN\" nomad/jobs INFLUX_TOKEN=\"$LC_INFLUX_TOKEN\" UNYT_DURABLE_OBJECTS_URL=\"$LC_UNYT_DURABLE_OBJECTS_URL\" UNYT_DURABLE_OBJECTS_SECRET=\"$LC_UNYT_DURABLE_OBJECTS_SECRET\""),
+			Triggers: pulumi.Array{
+				influxDBTokenSecret,
+				unytDurableObjectsURL,
+				unytDurableObjectsSecret,
+				droplet.ID(),
+			},
 		}, pulumi.DependsOn([]pulumi.Resource{aclBootstrap}))
 		if err != nil {
 			return err

--- a/nomad.hcl
+++ b/nomad.hcl
@@ -5,8 +5,8 @@ acl {
 }
 
 advertise {
-  http = "{{ GetPublicIP }}"
-  rpc  = "{{ GetPublicIP }}"
+  http = "nomad-server-01.holochain.org"
+  rpc  = "nomad-server-01.holochain.org"
 }
 
 server {


### PR DESCRIPTION
Takes over from #7, so that we are not re-applying multiple times.

This PR:

- Adds the `alloc-lifecycle` capability to the GitHub runner token policy which is required to allow the GitHub CI to stop/kill running Nomad allocations.
- Sets the server's advertised address to the URL instead of it's public IP, this means that if the IP changes then the clients should still be able to find the new server.
- Fixed a potential issue where updating the new Nomad Variables for the Unyt scenario would not trigger the command to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded job management permissions to include allocation lifecycle control capabilities.
  * Updated Nomad server endpoint configuration to use a fixed hostname instead of dynamic IP discovery, improving service discoverability.
  * Adjusted infrastructure configuration for service integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->