### PR TITLE
fix: add missing capabilities for Nomad policy used by CI workflows

### DIFF
--- a/job-runner.policy.hcl
+++ b/job-runner.policy.hcl
@@ -1,7 +1,7 @@
 # See https://developer.hashicorp.com/nomad/tutorials/access-control/access-control-policies for ACL Policy details
 
 namespace "default" {
-  capabilities = ["list-jobs", "read-job", "submit-job", "alloc-lifecycle"]
+  capabilities = ["list-jobs", "read-job", "submit-job", "alloc-lifecycle", "read-logs", "read-fs"]
 }
 
 node {

--- a/job-runner.policy.hcl
+++ b/job-runner.policy.hcl
@@ -1,7 +1,7 @@
 # See https://developer.hashicorp.com/nomad/tutorials/access-control/access-control-policies for ACL Policy details
 
 namespace "default" {
-  capabilities = ["list-jobs", "read-job", "submit-job", "alloc-lifecycle", "read-logs", "read-fs"]
+  capabilities = ["read-job", "submit-job", "alloc-lifecycle", "read-logs", "read-fs"]
 }
 
 node {

--- a/main.go
+++ b/main.go
@@ -262,7 +262,7 @@ func main() {
 			Environment: pulumi.StringMap{
 				"LC_ACL_TOKEN": aclTokenSecret,
 			},
-			Create: pulumi.String("nomad acl policy apply -address=https://localhost:4646 -ca-cert=/etc/nomad.d/nomad-agent-ca.pem -token=\"$LC_ACL_TOKEN\" -description=\"For running jobs, reading Node status, and cancelling allocations in CI workflows\" job-runner /etc/nomad.d/job-runner.policy.hcl"),
+			Create: pulumi.String("nomad acl policy apply -address=https://localhost:4646 -ca-cert=/etc/nomad.d/nomad-agent-ca.pem -token=\"$LC_ACL_TOKEN\" -description=\"For running jobs; reading Node status, logs, and file systems; and cancelling allocations in CI workflows\" job-runner /etc/nomad.d/job-runner.policy.hcl"),
 			Triggers: pulumi.Array{
 				copyJobRunnerPolicy.ID(),
 				aclBootstrap.ID(),

--- a/main.go
+++ b/main.go
@@ -198,6 +198,17 @@ func main() {
 			return err
 		}
 
+		nodeReaderPolicyFile := pulumi.NewFileAsset("./node-reader.policy.hcl")
+		copyNodeReaderPolicy, err := remote.NewCopyToRemote(ctx, "copy-node-reader-policy", &remote.CopyToRemoteArgs{
+			Connection: conn,
+			RemotePath: pulumi.String("/etc/nomad.d/node-reader.policy.hcl"),
+			Source:     nodeReaderPolicyFile,
+			Triggers:   pulumi.Array{nodeReaderPolicyFile, droplet.ID()},
+		}, pulumi.DependsOn([]pulumi.Resource{createEtcNomadDir}))
+		if err != nil {
+			return err
+		}
+
 		chownEtcNomadDirFinal, err := remote.NewCommand(ctx, "chown-etc-nomad-dir", &remote.CommandArgs{
 			Connection: conn,
 			Create:     pulumi.String("chown -R nomad:nomad /etc/nomad.d"),
@@ -265,6 +276,22 @@ func main() {
 			Create: pulumi.String("nomad acl policy apply -address=https://localhost:4646 -ca-cert=/etc/nomad.d/nomad-agent-ca.pem -token=\"$LC_ACL_TOKEN\" -description=\"For running jobs; reading Node status, logs, and file systems; and cancelling allocations in CI workflows\" job-runner /etc/nomad.d/job-runner.policy.hcl"),
 			Triggers: pulumi.Array{
 				copyJobRunnerPolicy.ID(),
+				aclBootstrap.ID(),
+				droplet.ID(),
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		_, err = remote.NewCommand(ctx, "apply-node-reader-policy", &remote.CommandArgs{
+			Connection: conn,
+			Environment: pulumi.StringMap{
+				"LC_ACL_TOKEN": aclTokenSecret,
+			},
+			Create: pulumi.String("nomad acl policy apply -address=https://localhost:4646 -ca-cert=/etc/nomad.d/nomad-agent-ca.pem -token=\"$LC_ACL_TOKEN\" -description=\"For reading the status of connected nodes\" node-reader /etc/nomad.d/node-reader.policy.hcl"),
+			Triggers: pulumi.Array{
+				copyNodeReaderPolicy.ID(),
 				aclBootstrap.ID(),
 				droplet.ID(),
 			},

--- a/node-reader.policy.hcl
+++ b/node-reader.policy.hcl
@@ -1,0 +1,5 @@
+# See https://developer.hashicorp.com/nomad/tutorials/access-control/access-control-policies for ACL Policy details
+
+node {
+  policy = "read"
+}


### PR DESCRIPTION
This PR:

* Adds two capabilities to the Nomad Policy used by the CI workflows
  * `read-logs`: used by `wait_for_jobs` step to print the logs of failed allocations.
  * `read-fs`: used to get the peer end count (currently just falls back to the total peer count).
* Removes the `list-jobs` capability as I don't think that is used anywhere.
* Adds a new policy for the Nomad node/client status dashboard with limited rights.

